### PR TITLE
chore: disable Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": false
+}


### PR DESCRIPTION
Adds `renovate.json` with `"enabled": false` so the Renovate app stops opening/recreating dependency PRs on this repo.

Renovate reads config from the **default branch**, so this must land on `main` to take effect. After merge, Renovate skips this repository on its next run.

Dependency updates will be handled manually going forward.

> Note: For complete removal, also uninstall the Renovate (Mend) GitHub App from the repo via **GitHub → Settings → Integrations / Installed GitHub Apps** (UI-only step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)