### PR TITLE
Fix scripted-EPUB rendering: forward epubOptions through ReactEpubViewer (v0.3.2) (#119)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-epub-viewer",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "NB",
     "email": "altmshfkgudtjr@naver.com"

--- a/src/modules/reactViewer/ReactViewer.tsx
+++ b/src/modules/reactViewer/ReactViewer.tsx
@@ -37,6 +37,8 @@ import BookType, { BookStyle, BookOption } from 'types/book';
 const ReactViewer = (
   {
     url,
+    epubFileOptions,
+    epubOptions,
     viewerLayout,
     viewerStyle,
     viewerStyleURL,
@@ -367,6 +369,8 @@ const ReactViewer = (
     <>
       <EpubViewer
         url={url}
+        epubFileOptions={epubFileOptions}
+        epubOptions={epubOptions}
         style={layoutStyle}
         bookChanged={bookChanged}
         rendtionChanged={rendtionChanged}

--- a/src/modules/viewer.test.tsx
+++ b/src/modules/viewer.test.tsx
@@ -361,4 +361,32 @@ describe('ReactEpubViewer (mocked epubjs)', () => {
     await waitFor(() => expect(rendition.handlers.touchend?.length).toBe(1));
     expect(rendition.handlers.mouseup?.length).toBe(1);
   });
+
+  it('forwards epubOptions to renderTo, e.g. allowScriptedContent (#119)', async () => {
+    render(
+      <ReactEpubViewer
+        url="a.epub"
+        ref={createRef()}
+        epubOptions={{ allowScriptedContent: true }}
+      />,
+    );
+    await waitFor(() =>
+      expect(MockBook.instances[0]?.renderTo).toHaveBeenCalled(),
+    );
+
+    const renderOpts = MockBook.instances[0].renderTo.mock.calls.at(-1)[1];
+    expect(renderOpts).toMatchObject({ allowScriptedContent: true });
+  });
+
+  it('forwards epubFileOptions to the epubjs Book (#119)', async () => {
+    render(
+      <ReactEpubViewer
+        url="a.epub"
+        ref={createRef()}
+        epubFileOptions={{ openAs: 'epub' }}
+      />,
+    );
+    await waitFor(() => expect(MockBook.instances.length).toBe(1));
+    expect(MockBook.instances[0].options).toMatchObject({ openAs: 'epub' });
+  });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,6 +78,11 @@ export interface EpubViewerProps {
  * React Epub Viewer Props
  * @type
  * @param url Epub file path
+ * @param epubFileOptions Epub file option (forwarded to epubjs `Book`)
+ * @param epubOptions Epub rendition option (forwarded to epubjs `renderTo`).
+ *   Set `allowScriptedContent: true` to run scripts embedded in the EPUB
+ *   (interactive / InDesign EPUBs). See the security note in the docs — only
+ *   enable this for content you trust.
  * @param viewerLayout Viewer layout
  * @param viewerStyle Viewer style
  * @param viewerStyleURL Viewer style - CSS URL
@@ -90,6 +95,8 @@ export interface EpubViewerProps {
  */
 export interface ReactViewerProps {
   url: string;
+  epubFileOptions?: BookOptions;
+  epubOptions?: RenditionOptions;
   viewerLayout?: ViewerLayout;
   viewerStyle?: BookStyle;
   viewerStyleURL?: string;


### PR DESCRIPTION
## Summary

Patch release **0.3.2**. Fixes #119 (and #36, same root cause, previously closed `NOT_PLANNED`).

The high-level `ReactEpubViewer` did not forward epubjs `Book`/`Rendition` options to the underlying `EpubViewer`, so consumers had **no way** to set `allowScriptedContent`. epubjs renders the content iframe with `sandbox="allow-same-origin"` only, so EPUBs containing `<script>` (interactive / InDesign EPUBs) fail with:

> Blocked script execution in 'about:srcdoc' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.

## Changes

| Change | Detail |
|--------|--------|
| `ReactViewerProps` | add `epubFileOptions?: BookOptions`, `epubOptions?: RenditionOptions` |
| `ReactViewer.tsx` | forward both props straight to `EpubViewer` |

Consumers can now opt in:

```tsx
<ReactEpubViewer url="book.epub" ref={ref} epubOptions={{ allowScriptedContent: true }} />
```

**All changes non-breaking** (additive props). Default sandbox behavior is unchanged (`allowScriptedContent` stays `false`).

## Security note

`allow-scripts` combined with `allow-same-origin` lets EPUB content run arbitrary scripts with access to the app origin — only enable for **trusted** EPUBs. A domain-level script allowlist was considered and rejected: iframe `sandbox` is token-based (no origin granularity), and CSP-based control is defeated by epubjs's post-load `hooks.content` timing plus the fact that most EPUB scripts are inline/in-archive. Documented in `docs/security.md`.

## Verification

- `yarn typecheck` ✅
- `yarn lint` ✅ (0 errors)
- `yarn test` ✅ 30 passing — 2 new regression tests (`epubOptions`→`renderTo`, `epubFileOptions`→`Book`)
- `yarn compile` ✅ — new props present in bundled `dist/index.d.ts`

Closes #119. Resolves #36.