### PR TITLE
fix: keep epubOptions/epubFileOptions referentially stable (v0.3.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-epub-viewer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": {
     "name": "NB",
     "email": "altmshfkgudtjr@naver.com"

--- a/src/lib/hooks/useStableValue.ts
+++ b/src/lib/hooks/useStableValue.ts
@@ -1,0 +1,26 @@
+import { useRef } from 'react';
+// utils
+import { deepEqual } from 'lib/utils/commonUtil';
+
+/**
+ * Return a referentially-stable version of `value`.
+ *
+ * The returned reference only changes when `value` is no longer *structurally*
+ * equal (see {@link deepEqual}) to the previous one. This lets consumers pass
+ * inline object literals (e.g. `epubOptions={{ allowScriptedContent: true }}`)
+ * without forcing effects keyed on that object to re-run on every render — which
+ * would otherwise thrash the epubjs book/rendition lifecycle.
+ *
+ * @param value Any value (typically an options object)
+ */
+export function useStableValue<T>(value: T): T {
+  const ref = useRef(value);
+
+  if (!deepEqual(ref.current, value)) {
+    ref.current = value;
+  }
+
+  return ref.current;
+}
+
+export default useStableValue;

--- a/src/lib/utils/commonUtil.ts
+++ b/src/lib/utils/commonUtil.ts
@@ -213,6 +213,41 @@ export const getSelectionPosition = (
 };
 
 /**
+ * Structural (deep) equality for plain values.
+ *
+ * Used to keep option objects (`epubOptions` / `epubFileOptions`) referentially
+ * stable across renders: two object literals with the same contents are treated
+ * as equal so effects keyed on them do not re-run. Functions and other
+ * non-plain values are compared by reference (`Object.is`).
+ * @param a First value
+ * @param b Second value
+ */
+export const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (Object.is(a, b)) return true;
+  if (
+    typeof a !== 'object' ||
+    typeof b !== 'object' ||
+    a === null ||
+    b === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(a as Record<string, unknown>);
+  const keysB = Object.keys(b as Record<string, unknown>);
+  if (keysA.length !== keysB.length) return false;
+
+  return keysA.every(
+    key =>
+      Object.prototype.hasOwnProperty.call(b, key) &&
+      deepEqual(
+        (a as Record<string, unknown>)[key],
+        (b as Record<string, unknown>)[key],
+      ),
+  );
+};
+
+/**
  * Debounce
  * @param func Target function
  * @param timeout delay

--- a/src/modules/epubViewer/EpubViewer.tsx
+++ b/src/modules/epubViewer/EpubViewer.tsx
@@ -8,6 +8,8 @@ import React, {
 import { Book, Rendition } from 'epubjs';
 // style
 import styles from 'modules/epubViewer/styles';
+// hooks
+import { useStableValue } from 'lib/hooks/useStableValue';
 // types
 import { EpubViewerProps, ViewerRef } from 'types';
 import Loc from 'types/loc';
@@ -32,8 +34,8 @@ import Loc from 'types/loc';
 const EpubViewer = (
   {
     url,
-    epubFileOptions,
-    epubOptions,
+    epubFileOptions: epubFileOptionsProp,
+    epubOptions: epubOptionsProp,
     style,
     location,
     bookChanged,
@@ -45,6 +47,13 @@ const EpubViewer = (
   }: EpubViewerProps,
   ref: React.ForwardedRef<ViewerRef>,
 ) => {
+  // Keep option objects referentially stable so that passing an inline literal
+  // (e.g. `epubOptions={{ allowScriptedContent: true }}`) does not re-run the
+  // book/rendition effects on every render. Recreating the rendition on each
+  // render races the epubjs lifecycle and can crash rendering ("Cannot read
+  // properties of undefined (reading 'package')") → the book never loads.
+  const epubFileOptions = useStableValue(epubFileOptionsProp);
+  const epubOptions = useStableValue(epubOptionsProp);
   /**
    * This component requires an object ref (not a callback ref) because it both
    * forwards the ref to the wrapper element and augments `ref.current` with

--- a/src/modules/viewer.test.tsx
+++ b/src/modules/viewer.test.tsx
@@ -389,4 +389,63 @@ describe('ReactEpubViewer (mocked epubjs)', () => {
     await waitFor(() => expect(MockBook.instances.length).toBe(1));
     expect(MockBook.instances[0].options).toMatchObject({ openAs: 'epub' });
   });
+
+  // Regression: passing an inline `epubOptions` object literal used to give a
+  // new reference every render, re-running the rendition effect and recreating
+  // the rendition on each render. That races the epubjs lifecycle and crashes
+  // rendering ("reading 'package'") so the book never loads (infinite loading).
+  it('does not recreate the rendition when epubOptions is an equal inline object', async () => {
+    const { rerender } = render(
+      <EpubViewer url="a.epub" ref={createRef()} epubOptions={{ allowScriptedContent: true }} />,
+    );
+    await waitFor(() =>
+      expect(MockBook.instances[0]?.renderTo).toHaveBeenCalledTimes(1),
+    );
+
+    // Re-render with a brand-new object of identical shape (simulates a parent
+    // re-render passing `{{ allowScriptedContent: true }}` again).
+    rerender(
+      <EpubViewer url="a.epub" ref={createRef()} epubOptions={{ allowScriptedContent: true }} />,
+    );
+    rerender(
+      <EpubViewer url="a.epub" ref={createRef()} epubOptions={{ allowScriptedContent: true }} />,
+    );
+
+    // No new Book, and the rendition was NOT recreated.
+    expect(MockBook.instances.length).toBe(1);
+    expect(MockBook.instances[0].renderTo).toHaveBeenCalledTimes(1);
+  });
+
+  it('recreates the rendition when epubOptions actually changes value', async () => {
+    const { rerender } = render(
+      <EpubViewer url="a.epub" ref={createRef()} epubOptions={{ allowScriptedContent: true }} />,
+    );
+    await waitFor(() =>
+      expect(MockBook.instances[0]?.renderTo).toHaveBeenCalledTimes(1),
+    );
+
+    rerender(
+      <EpubViewer url="a.epub" ref={createRef()} epubOptions={{ allowScriptedContent: false }} />,
+    );
+
+    await waitFor(() =>
+      expect(MockBook.instances[0].renderTo).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it('does not recreate the Book when epubFileOptions is an equal inline object', async () => {
+    const { rerender } = render(
+      <EpubViewer url="a.epub" ref={createRef()} epubFileOptions={{ openAs: 'epub' }} />,
+    );
+    await waitFor(() => expect(MockBook.instances.length).toBe(1));
+
+    rerender(
+      <EpubViewer url="a.epub" ref={createRef()} epubFileOptions={{ openAs: 'epub' }} />,
+    );
+    rerender(
+      <EpubViewer url="a.epub" ref={createRef()} epubFileOptions={{ openAs: 'epub' }} />,
+    );
+
+    expect(MockBook.instances.length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Problem

Passing an inline object literal for `epubOptions` / `epubFileOptions` (e.g. `epubOptions={{ allowScriptedContent: true }}`) gives a **new reference on every render**. Both lifecycle effects are keyed on these objects:

- book effect — `[url, epubFileOptions]`
- rendition effect — `[book, epubOptions, viewerRef]`

So they re-ran on every render and recreated the epubjs book/rendition repeatedly. Under frequent re-renders (Redux state, page counter, etc.) this races the epubjs lifecycle: a queued `Rendition.start()` runs after teardown and throws `Cannot read properties of undefined (reading 'package')`, the content iframe never mounts, and the viewer **hangs on the loading view (infinite loading)**.

This surfaced while enabling `allowScriptedContent: true` (needed for Safari text selection/highlight, since WebKit doesn't dispatch events to a `sandbox="allow-same-origin"` iframe without `allow-scripts`).

## Fix

Stabilize both option objects with a new `useStableValue` hook backed by a `deepEqual` util. The reference only changes when the options **structurally** change, so equal inline literals no longer retrigger the effects. Legitimate value changes still recreate the book/rendition.

## Changes
- `deepEqual` (`lib/utils/commonUtil.ts`)
- `useStableValue` (`lib/hooks/useStableValue.ts`)
- Apply to `epubFileOptions` / `epubOptions` in `EpubViewer`
- 3 regression tests

## Verification
- `typecheck` / `lint` clean, **33 tests passing**
- Reproduced with Playwright **WebKit + Chromium**: under aggressive re-render with an inline `epubOptions`, the book now loads with no `'package'` crash (previously infinite loading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)